### PR TITLE
Bump paperless to 2.19.3

### DIFF
--- a/manifests/paperless/overlay/kustomization.yaml
+++ b/manifests/paperless/overlay/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: "14"
 - name: ghcr.io/paperless-ngx/paperless-ngx
   newName: ghcr.io/paperless-ngx/paperless-ngx
-  newTag: 2.19.2
+  newTag: 2.19.3


### PR DESCRIPTION
Automated bump of paperless to 2.19.3

Closes: #202