### PR TITLE
Bump paperless to 2.19.6

### DIFF
--- a/manifests/paperless/overlay/kustomization.yaml
+++ b/manifests/paperless/overlay/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: "14"
 - name: ghcr.io/paperless-ngx/paperless-ngx
   newName: ghcr.io/paperless-ngx/paperless-ngx
-  newTag: 2.19.5
+  newTag: 2.19.6


### PR DESCRIPTION
Automated bump of paperless to 2.19.6

Closes: #228