### PR TITLE
Bump zwavejs2mqtt to 11.8.1

### DIFF
--- a/manifests/zwavejs2mqtt/overlay/kustomization.yaml
+++ b/manifests/zwavejs2mqtt/overlay/kustomization.yaml
@@ -17,4 +17,4 @@ patches:
 images:
 - name: ghcr.io/zwave-js/zwave-js-ui
   newName: ghcr.io/zwave-js/zwave-js-ui
-  newTag: 11.8.0
+  newTag: 11.8.1


### PR DESCRIPTION
Automated bump of zwavejs2mqtt to 11.8.1

Closes: #245