### PR TITLE
Bump paperless to 11691-document-filter-anchor

### DIFF
--- a/manifests/paperless/overlay/kustomization.yaml
+++ b/manifests/paperless/overlay/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: "14"
 - name: ghcr.io/paperless-ngx/paperless-ngx
   newName: ghcr.io/paperless-ngx/paperless-ngx
-  newTag: 2.20.3
+  newTag: 11691-document-filter-anchor


### PR DESCRIPTION
Automated bump of paperless to 11691-document-filter-anchor

Closes: #283