### PR TITLE
Bump paperless to dependabot-uv-virtualenv-20.36.1

### DIFF
--- a/manifests/paperless/overlay/kustomization.yaml
+++ b/manifests/paperless/overlay/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: "14"
 - name: ghcr.io/paperless-ngx/paperless-ngx
   newName: ghcr.io/paperless-ngx/paperless-ngx
-  newTag: 2.20.3
+  newTag: dependabot-uv-virtualenv-20.36.1


### PR DESCRIPTION
Automated bump of paperless to dependabot-uv-virtualenv-20.36.1

Closes: #291