### PR TITLE
Bump zwavejs2mqtt to 11.10.0

### DIFF
--- a/manifests/zwavejs2mqtt/overlay/kustomization.yaml
+++ b/manifests/zwavejs2mqtt/overlay/kustomization.yaml
@@ -17,4 +17,4 @@ patches:
 images:
 - name: ghcr.io/zwave-js/zwave-js-ui
   newName: ghcr.io/zwave-js/zwave-js-ui
-  newTag: 11.9.1
+  newTag: 11.10.0


### PR DESCRIPTION
Automated bump of zwavejs2mqtt to 11.10.0

Closes: #295