### PR TITLE
Bump dsmr-reader to 5.12.0-2026.01.02

### DIFF
--- a/manifests/dsmr-reader/overlay/kustomization.yaml
+++ b/manifests/dsmr-reader/overlay/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: "14"
 - name: ghcr.io/xirixiz/dsmr-reader-docker
   newName: ghcr.io/xirixiz/dsmr-reader-docker
-  newTag: 5.12.0-2026.01.01
+  newTag: 5.12.0-2026.01.02
 
 labels:
 - includeSelectors: true


### PR DESCRIPTION
Automated bump of dsmr-reader to 5.12.0-2026.01.02

Closes: #308