### PR TITLE
Bump paperless to 2.20.8

### DIFF
--- a/manifests/paperless/overlay/kustomization.yaml
+++ b/manifests/paperless/overlay/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: "14"
 - name: ghcr.io/paperless-ngx/paperless-ngx
   newName: ghcr.io/paperless-ngx/paperless-ngx
-  newTag: 2.20.7
+  newTag: 2.20.8


### PR DESCRIPTION
Automated bump of paperless to 2.20.8

Closes: #345