### PR TITLE
Bump vaultwarden to 1.35.4

### DIFF
--- a/manifests/vaultwarden/overlay/kustomization.yaml
+++ b/manifests/vaultwarden/overlay/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: "14"
 - name: ghcr.io/dani-garcia/vaultwarden
   newName: ghcr.io/dani-garcia/vaultwarden
-  newTag: 1.35.3
+  newTag: 1.35.4


### PR DESCRIPTION
Automated bump of vaultwarden to 1.35.4

Closes: #347