### PR TITLE
Bump radicale to 3.6.1.0

### DIFF
--- a/manifests/radicale/overlay/kustomization.yaml
+++ b/manifests/radicale/overlay/kustomization.yaml
@@ -14,4 +14,4 @@ namespace: tools
 images:
 - name: docker.io/tomsquest/docker-radicale
   newName: docker.io/tomsquest/docker-radicale
-  newTag: 3.6.0.0
+  newTag: 3.6.1.0


### PR DESCRIPTION
Automated bump of radicale to 3.6.1.0

Closes: #349