### PR TITLE
Bump vaultwarden to 1.37.0

### DIFF
--- a/manifests/vaultwarden/overlay/kustomization.yaml
+++ b/manifests/vaultwarden/overlay/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: "14"
 - name: ghcr.io/dani-garcia/vaultwarden
   newName: ghcr.io/dani-garcia/vaultwarden
-  newTag: 1.36.0
+  newTag: 1.37.0


### PR DESCRIPTION
Automated bump of vaultwarden to 1.37.0

Closes: #470